### PR TITLE
Setup MiniTest. Let unknown attributes be ignored during initialization in RunKeeper::Activity

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,24 @@
-require 'bundler/gem_tasks'
+begin
+  require 'rubygems'
+  require 'bundler'
+rescue LoadError
+  raise 'Could not load the bundler gem. Install it with `gem install bundler`.'
+end
+
+begin
+  Bundler.setup
+rescue Bundler::GemNotFound
+  raise RuntimeError, "Bundler couldn't find some gems." +
+    "Did you run `bundle install`?"
+end
+
+Bundler::GemHelper.install_tasks
+
+require 'rake/testtask'
+
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'test'
+  test.pattern = 'test/**/*_test.rb'
+end
+
+task :default => :test

--- a/lib/run_keeper/activity.rb
+++ b/lib/run_keeper/activity.rb
@@ -5,7 +5,7 @@ module RunKeeper
 
     def initialize attributes = {}
       attributes.each do |attribute, value|
-        send :"#{attribute}=", value
+        send :"#{attribute}=", value if respond_to? :"#{attribute}="
       end
     end
 

--- a/run_keeper.gemspec
+++ b/run_keeper.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_development_dependency 'rake', '~> 0.9.2'
   s.add_dependency 'activesupport', '~> 3.1.0'
   s.add_dependency 'oauth2', '~> 0.5.0'
 end

--- a/test/activity_test.rb
+++ b/test/activity_test.rb
@@ -1,0 +1,7 @@
+require 'helper'
+
+class ActivityTest < MiniTest::Unit::TestCase
+  def test_initailization_ignores_unknown_attributes
+    refute_match Activity.new(:foo => 'bar').instance_variables, /foo/
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,4 @@
+require 'minitest/autorun'
+require 'run_keeper'
+
+include RunKeeper


### PR DESCRIPTION
Looking good man.

First thing that came to mind was passing a hash with unknown attributes would cause a NoMethodError. I've only patched one class and setup tests because I wasn't sure if you are going to accept this.

Tate.
