### PR TITLE
Setting of token

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ runkeeper = RunKeeper.new 'client_id', 'client_secret'
 runkeeper.authorize_url 'http://your.com/callback/url'
 # => 'https://runkeeper.com/apps/authorize?response_type=code&client_id=client_id&redirect_uri=http%3A%2F%2Fyour.com%2Fcallback%2Furl'
 
-runkeeper.token = runkeeper.get_token 'authorization_code_value', 'http://your.com/callback/url'
+runkeeper.get_token 'authorization_code_value', 'http://your.com/callback/url'
 
 # return the users profile
 runkeeper.profile

--- a/lib/run_keeper/request.rb
+++ b/lib/run_keeper/request.rb
@@ -21,7 +21,7 @@ module RunKeeper
     end
 
     def get_token code, redirect_uri
-      client('https://runkeeper.com').auth_code.get_token(code, :redirect_uri => redirect_uri).token
+      @token = client('https://runkeeper.com').auth_code.get_token(code, :redirect_uri => redirect_uri).token
     rescue OAuth2::Error => e
       raise Error.new(e.response)
     end


### PR DESCRIPTION
The token= from the README did not exist.
I made the @token variable set when calling
calling #get_token so the dev doesn't have to set
it back into the Request object.

Also removed token= setting from README.