### PR TITLE
Fixed NoMethodError map for NilClass error on `runkeeper.fitness_activities options`

### DIFF
--- a/lib/run_keeper/activity_request.rb
+++ b/lib/run_keeper/activity_request.rb
@@ -21,18 +21,10 @@ module RunKeeper
         activities -= activities.reject { |activity| (activity.start_time > @options[:start]) && (activity.start_time < @options[:finish]) }
       end
 
-      if response.parsed['next']
-        if @options[:limit]
-          if activities.size < @options[:limit]
-            @options[:params].update(:page => response.parsed['next'].split('=').last)
-            activities + request(activities)
-          else
-            activities
-          end
-        else
-          @options[:params].update(:page => response.parsed['next'].split('=').last)
-          activities + request(activities)
-        end
+      if response.parsed['next'] && (@options[:limit].nil? || activities.size < @options[:limit])
+        next_page = response.parsed['next'].scan(/page=(\d+)/)[0][0]
+        @options[:params].update(:page => next_page)
+        activities + request(activities)
       else
         activities
       end

--- a/lib/run_keeper/activity_request.rb
+++ b/lib/run_keeper/activity_request.rb
@@ -15,7 +15,7 @@ module RunKeeper
 
     def request activities = nil
       response   = @runkeeper.request('fitness_activities', @options[:params])
-      activities = response.parsed['items'].map { |activity| Activity.new(activity) }
+      activities = response.parsed['items'] ? response.parsed['items'].map { |activity| Activity.new(activity) } : []
 
       if @options[:start]
         activities -= activities.reject { |activity| (activity.start_time > @options[:start]) && (activity.start_time < @options[:finish]) }


### PR DESCRIPTION
@coop : First, thanks for the awesome work :+1: 

Recently, I ran into this issue when I do something like the following steps:

``` ruby
runkeeper = RunkeeperProfile.get_runkeeper_client '<some token>'
finish=Time.now
start=2.days.ago
options = {start: start, finish: finish}
runkeeper.fitness_activities options
```

I get the following error:

``` ruby
irb(main):007:0* options = {start: start, finish: finish}
=> {:start=>Wed, 11 Mar 2015 01:43:20 CET +01:00, :finish=>2015-03-13 01:43:20 +0100}
irb(main):008:0>
irb(main):009:0* runkeeper.fitness_activities options
NoMethodError: undefined method `map' for nil:NilClass
    from /Users/pareshsharma/Workspace/CRunkeeper/vendor/bundle/gems/run_keeper-0.0.5/lib/run_keeper/activity_request.rb:18:in `request'
    from /Users/pareshsharma/Workspace/CRunkeeper/vendor/bundle/gems/run_keeper-0.0.5/lib/run_keeper/activity_request.rb:34:in `request'
    from /Users/pareshsharma/Workspace/CRunkeeper/vendor/bundle/gems/run_keeper-0.0.5/lib/run_keeper/activity_request.rb:8:in `get_activities'
    from /Users/pareshsharma/Workspace/CRunkeeper/vendor/bundle/gems/run_keeper-0.0.5/lib/run_keeper/request.rb:18:in `fitness_activities'
```

P.S.
Also, I am working on using [Time Scope](http://developer.runkeeper.com/healthgraph/example-api-calls#example-get-retrieving-user-info) while fetching activities from RunKeeper, hopefully I'll create a pull request sometime soon.
